### PR TITLE
[BAI-313] Fix quoteapp init script

### DIFF
--- a/templates/default/quoteapp.conf.erb
+++ b/templates/default/quoteapp.conf.erb
@@ -14,5 +14,5 @@ setgid <%= node['quoteapp']['group'] %>
 
 script
   cd <%= node['quoteapp']['install_dir'] %>
-  NODE_CONFIG='<%= {logger_app_url: node['quoteapp']['logger_app_url']}.to_s %>' exec npm start > /dev/null
+  NODE_CONFIG='<%= {logger_app_url: node['quoteapp']['logger_app_url']}.to_json %>' exec npm start > /dev/null
 end script


### PR DESCRIPTION
The NODE_CONFIG variable receives a json, not a string version of a
hash.

Shame on me.
